### PR TITLE
add python-dev to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The commands assume RedHat/CentOS environment.
 # Rquirements: JDK & Ant
 
 # Install dependencies
-sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools
+sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-dev
 
 # Clone & Build
 git clone https://github.com/naver/arcus.git

--- a/docs/howto-install-dependencies.md
+++ b/docs/howto-install-dependencies.md
@@ -33,8 +33,8 @@ How To Install Dependencies
 - Install tools for packaging and building
 
   ```
-  (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools
-  (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools
+  (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-dev
+  (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev
   ```
 
 - For OSX users

--- a/scripts/fabfile.py
+++ b/scripts/fabfile.py
@@ -64,7 +64,7 @@ def is_localhost(host=None):
   if host == os.getenv('HOSTNAME'):
     return True
 
-  if host == socket.gethostbyname(os.getenv('HOSTNAME')):
+  if host == socket.gethostbyname(socket.gethostname()):
     return True
     
   return False


### PR DESCRIPTION
somtimes pyton-dev didn't installed, then occur Python.h error
please add python-dev to dependencies

가끔 python-dev가 설치되지 않아서 build.sh를 수행하는 중 Python.h가 없다는 에러가 발생합니다.
dependencies에 python-dev를 추가해주시면 감사하겠습니다.