### PR TITLE
Make scripts executable inside the documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,16 @@ They build memcached, set up a cloud of two memcached nodes in ZooKeeper, and st
 The commands assume RedHat/CentOS environment.
 
 ```
+#!/bin/bash
+
 # Requirements: JDK & Ant
 
 # Install dependencies
-sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel (CentOS)
-sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev (Ubuntu)
-
+if [ $(which yum) ]; then
+    sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel
+elif [ $(which apt-get) ]; then
+    sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev
+fi
 
 # Clone & Build
 git clone https://github.com/naver/arcus.git
@@ -73,9 +77,9 @@ cd arcus/scripts
 
 # Test
 echo "stats" | nc localhost 11211 | grep version
-STAT version 1.7.0
+# STAT version 1.7.0
 echo "stats" | nc localhost 11212 | grep version
-STAT version 1.7.0
+# STAT version 1.7.0
 ```
 
 To set up Arcus cache clouds on multiple machines, you need following two things.

--- a/docs/howto-install-dependencies.md
+++ b/docs/howto-install-dependencies.md
@@ -43,8 +43,8 @@ How To Install Dependencies
 - Install tools for packaging and building
 
   ```
-  $ sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel	# CentOS
-  $ sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev		# Ubuntu
+  (CentOS)$ sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel
+  (Ubuntu)$ sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev
   ```
 
 - For OSX users

--- a/docs/howto-install-dependencies.md
+++ b/docs/howto-install-dependencies.md
@@ -4,13 +4,18 @@ How To Install Dependencies
 - Install JDK & Ant
 
   ```
+  #!/bin/bash
+
   # Make a directory
   mkdir ~/vendor
   pushd ~/vendor
 
   # Install openjdk
-  sudo yum install java-1.7.0-openjdk-devel (CentOS)
-  sudo apt-get install openjdk-7-jdk (Ubuntu)
+  if [ $(which yum) ]; then
+      sudo yum install java-1.7.0-openjdk-devel
+  elif [ $(which apt-get) ]; then
+      sudo apt-get install openjdk-7-jdk
+  fi
 
   # Or download it directly from Oracle
   http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html
@@ -26,15 +31,20 @@ How To Install Dependencies
   export ANT_HOME=$HOME/vendor/ant
   export PATH=$JAVA_HOME/bin:$ANT_HOME/bin:$PATH
 
-  source ~/.bashrc (or ~/.bash_profile)
+  if [ -f ~/.bashrc ]; then
+      source ~/.bashrc
+  elif [ -f ~/.bash_profile ]; then  
+      source ~/.bash_profile
+  fi
+
   popd 
   ```
 
 - Install tools for packaging and building
 
   ```
-  (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel
-  (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev
+  $ sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel	# CentOS
+  $ sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev		# Ubuntu
   ```
 
 - For OSX users


### PR DESCRIPTION
`README.md`와 `docs/howto-install-dependencies.md` 에는 shell script 형태의 quickstart 코드를 포함하고 있어 새로운 사용자들이 쉽게 arcus를 설치할 수 있게 되어 있습니다.
그러나 코드 중간에 종종 CentOS와 Ubuntu를 구분해 두는 부분으로 인해 script를 그대로 실행하기는 불가능합니다. 
예를 들어, 다음과 같습니다.
```
# Install dependencies
sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel (CentOS)
sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev (Ubuntu)
```

이를 자동으로 처리할 수 있게끔 script를 고쳐준다면 사용자가 바로 설치를 해볼 수 있다는 점에서 더 편의성을 가져다 줄 것이라고 생각합니다.