### PR TITLE
Fix problems installing python packages by easy_install on centos6

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -98,18 +98,19 @@ build_all() {
 
   # install python-kazoo, python-fabric
   local pythonpath=$target_dir/lib/python/site-packages
+  local pythonsimpleindex=https://pypi.python.org/simple
   mkdir -p $pythonpath
   export PYTHONPATH=$pythonpath:$PYTHONPATH
   printf "[python kazoo library install] .. START"
-  easy_install -a -d $pythonpath kazoo 1>> $arcus_directory/scripts/build.log 2>&1
+  easy_install -a -d $pythonpath -i $pythonsimpleindex kazoo 1>> $arcus_directory/scripts/build.log 2>&1 
   printf "\r[python kazoo library install] .. SUCCEED\n"
   printf "[python jinja2 library install] .. START"
-  easy_install -a -d $pythonpath jinja2 1>> $arcus_directory/scripts/build.log 2>&1
+  easy_install -a -d $pythonpath -i $pythonsimpleindex jinja2 1>> $arcus_directory/scripts/build.log 2>&1 
   printf "\r[python jinja2 library install] .. SUCCEED\n"
   # FIXME pycrypto-2.6 is really really slow.. So let's downgrade it.
-  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
+  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "[python fabric library install] .. START"
-  easy_install -a -d $pythonpath fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
+  easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1 
   printf "\r[python fabric library install] .. SUCCEED\n"
   pushd $target_dir/scripts >> $arcus_directory/scripts/build.log
   if [ ! -f fab ]; then


### PR DESCRIPTION
- CentOS6 버전에서 arcus를 build하면 python 패키지 설치가 안되는 문제. easy_install이 distribute 버전이면 문제가 되는 것 같다.
  - Solution 1) easy_install의 i 옵션을 사용.
  - Solution 2) easy_install을 업그레이드
```
$ wget https://pypi.python.org/packages/b8/04/be569e393006fa9a2c10ef72ea33133c2902baa115dd1d4279dae55c3b3b/setuptools-36.8.0.zip
$ unzip setuptools-36.8.0.zip
$ cd setuptools-36.8.0
$ python setup.py install
$ easy_install -U setuptools
$ easy_install --version
setuptools 36.8.0 from /usr/lib....
```
- 이슈 내용
```
$ cat /etc/redhat-release
CentOS release 6.9 (Final)

$ easy_install --version
distribute 0.6.10

$ python --version
Python 2.6.6

$ cd ~/arcus/scripts
$ ./build.sh
ARCUS BUILD PROCESS: START                               
--------------------------                               
Working directory is /home/hjyun/arcus.                  
Detailed build log is recorded to scripts/build.log.     
--------------------------                               
[git submodule init] .. SUCCEED                          
[git submodule update] .. SUCCEED                        
[server/config/autorun.sh] .. SUCCEED                    
[clients/c/config/autorun.sh] .. SUCCEED                 
[zookeeper/ant clean compile_jute bin-package] .. SUCCEED
[zookeeper/src/c/autoreconf -if] .. SUCCEED              
[deps/libevent make clean] .. SUCCEED                    
[deps/libevent make] .. SUCCEED                          
[deps/libevent make install] .. SUCCEED                  
[zookeeper/src/c make clean] .. SUCCEED                  
[zookeeper/src/c make] .. SUCCEED                        
[zookeeper/src/c make install] .. SUCCEED                
[server make clean] .. SUCCEED                           
[server make] .. SUCCEED                                 
[server make install] .. SUCCEED                         
[python kazoo library install] .. SUCCEED                
[python jinja2 library install] .. SUCCEED               
[python fabric library install] .. SUCCEED               
--------------------------                               
ARCUS BUILD PROCESS: END                     

$ ls -l
-rwxrwxr-x 1 hjyun hjyun   4535 Feb 23 01:50 arcus.sh
-rw-rw-r-- 1 hjyun hjyun 190028 Feb 23 01:52 build.log
-rwxrwxr-x 1 hjyun hjyun   5064 Feb 23 01:50 build.sh
drwxrwxr-x 2 hjyun hjyun   4096 Feb 23 01:50 conf
drwxrwxr-x 2 hjyun hjyun   4096 Feb 23 01:50 etc
lrwxrwxrwx 1 hjyun hjyun     31 Feb 23 01:52 fab -> ../lib/python/site-packages/fab
-rw-rw-r-- 1 hjyun hjyun  18592 Feb 23 01:50 fabfile.py
drwxrwxr-x 2 hjyun hjyun   4096 Feb 23 01:50 lib

$ ls -l ../lib/python/site-packages
site.py  site.pyc

$ cat build.log
...
Searching for kazoo
Reading http://pypi.python.org/simple/kazoo/
Couldn't find index page for 'kazoo' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading http://pypi.python.org/simple/
No local packages or download links found for kazoo
error: Could not find suitable distribution for Requirement.parse('kazoo') (--always-copy skips system and development eggs)
Searching for jinja2
Reading http://pypi.python.org/simple/jinja2/
Couldn't find index page for 'jinja2' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading http://pypi.python.org/simple/
No local packages or download links found for jinja2
error: Could not find suitable distribution for Requirement.parse('jinja2') (--always-copy skips system and development eggs)
Searching for pycrypto==2.4.1
Reading http://pypi.python.org/simple/pycrypto/
Couldn't find index page for 'pycrypto' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading http://pypi.python.org/simple/
No local packages or download links found for pycrypto==2.4.1
error: Could not find suitable distribution for Requirement.parse('pycrypto==2.4.1') (--always-copy skips system and development eggs)
Searching for fabric==1.8.3
Reading http://pypi.python.org/simple/fabric/
Couldn't find index page for 'fabric' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading http://pypi.python.org/simple/
No local packages or download links found for fabric==1.8.3
error: Could not find suitable distribution for Requirement.parse('fabric==1.8.3') (--always-copy skips system and development eggs)
```
- 참고
  - https://groups.google.com/forum/#!topic/openarcus/wtR54-xXZ7s
  - https://bugzilla.redhat.com/show_bug.cgi?id=1510444

