### PR TITLE
Update python submodules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The commands assume RedHat/CentOS environment.
 ```
 # Requirements: JDK & Ant
 
-# Install dependencies
+# Install dependencies (python >= 2.6)
 sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel (CentOS)
 sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev (Ubuntu)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,7 +30,7 @@ get_working_directory() {
 }
 
 ## Common build script
-## 
+##
 ## @param $1 source directory
 ## @param $2 target directory
 ## @param $3 module
@@ -64,7 +64,7 @@ build_and_install() {
 }
 
 ## Bulid all components
-## 
+##
 ## @param $1 source directory
 ## @param $2 target directory
 build_all() {
@@ -97,20 +97,24 @@ build_all() {
   fi
 
   # install python-kazoo, python-fabric
+  local pythonmajorversion=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)' | cut -d'.' -f1)
   local pythonpath=$target_dir/lib/python/site-packages
   local pythonsimpleindex=https://pypi.python.org/simple
   mkdir -p $pythonpath
   export PYTHONPATH=$pythonpath:$PYTHONPATH
   printf "[python kazoo library install] .. START"
-  easy_install -a -d $pythonpath -i $pythonsimpleindex kazoo 1>> $arcus_directory/scripts/build.log 2>&1 
+  easy_install -a -d $pythonpath -i $pythonsimpleindex kazoo==2.6.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python kazoo library install] .. SUCCEED\n"
   printf "[python jinja2 library install] .. START"
-  easy_install -a -d $pythonpath -i $pythonsimpleindex jinja2 1>> $arcus_directory/scripts/build.log 2>&1 
+  easy_install -a -d $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python jinja2 library install] .. SUCCEED\n"
-  # FIXME pycrypto-2.6 is really really slow.. So let's downgrade it.
-  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
+  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
   printf "[python fabric library install] .. START"
-  easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1 
+  if [ $pythonmajorversion == "3" ]; then
+    easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
+  else
+    easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==1.14.0 1>> $arcus_directory/scripts/build.log 2>&1
+  fi
   printf "\r[python fabric library install] .. SUCCEED\n"
   pushd $target_dir/scripts >> $arcus_directory/scripts/build.log
   if [ ! -f fab ]; then


### PR DESCRIPTION
arcus 빌드 과정에서 jinja2를 다운로드할 때 모듈 버전이 명시되어 있지 않아서 최신 버전을 다운받아 호환성 문제가 발생합니다. 다운받을 모듈 버전을 명시하였습니다.

./build.sh
```
Searching for jinja2
 Reading https://pypi.python.org/simple/jinja2/
 Best match: Jinja2 3.0.0a1
 Downloading https://files.pythonhosted.org/packages/36/cc/                              5cd404a00f1b93bc830505c7a78553d9f49f7152c336466fc206790cc26c/Jinja2-3.0.0a1.tar.        gz#sha256=c922560ac46888d47384de1dbdc3daaa2ea993af4b26a436dec31fa2c19ec668
 Processing Jinja2-3.0.0a1.tar.gz
 Writing /tmp/easy_install-X7jwZM/Jinja2-3.0.0a1/setup.cfg
 Running Jinja2-3.0.0a1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-X7jwZM/       Jinja2-3.0.0a1/egg-dist-tmp-X1VERR
 Traceback (most recent call last):
   File "/usr/bin/easy_install", line 9, in <module>
     load_entry_point('setuptools==0.9.8', 'console_scripts', 'easy_install')()
   File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line      1992, in 
....
TypeError: 'encoding' is an invalid keyword argument for this function
```
