### PR TITLE
Roll backed the version of python submodules to be installed.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,7 +97,7 @@ build_all() {
   fi
 
   # install python-kazoo, python-fabric
-  local pythonmajorversion=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)' | cut -d'.' -f1)
+  local pythonmajorversion=$(python -c 'import sys; print(sys.version_info[0])')
   local pythonpath=$target_dir/lib/python/site-packages
   local pythonsimpleindex=https://pypi.python.org/simple
   mkdir -p $pythonpath
@@ -108,12 +108,14 @@ build_all() {
   printf "[python jinja2 library install] .. START"
   easy_install -a -d $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python jinja2 library install] .. SUCCEED\n"
-  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
   printf "[python fabric library install] .. START"
-  if [ $pythonmajorversion == "3" ]; then
+  if [ "$pythonmajorversion" == "3" ]; then
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
     easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
   else
-    easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==1.14.0 1>> $arcus_directory/scripts/build.log 2>&1
+    # FIXME pycrypto-2.6 is really really slow.. So let's downgrade it.
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future easy_install -a -d $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
+    easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
   fi
   printf "\r[python fabric library install] .. SUCCEED\n"
   pushd $target_dir/scripts >> $arcus_directory/scripts/build.log


### PR DESCRIPTION
build.sh 수정 사항입니다.
- mac os에는 grep -P 옵션이 없어서 정규표현식 수정
- 문법에러
- roll back fabric, pycrypto version on python 2
   : linux에 default로 설치되는 setuptools 버전을 고려하여 fabric 버전을 롤백함. 롤백한 fabric 모듈은pycrytodome을 사용하지 못하는 것 같아 pycrypto를 설치하도록 롤백.

@hjyun328 리뷰 요청드립니다.