### PR TITLE
FIX: specify markupsafe version(dependency for jinja)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -105,6 +105,9 @@ build_all() {
   printf "[python kazoo library install] .. START"
   easy_install -a -d $pythonpath -i $pythonsimpleindex kazoo==2.6.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python kazoo library install] .. SUCCEED\n"
+  printf "[python markupsafe library install] .. START"
+  easy_install -a -d $pythonpath -i $pythonsimpleindex markupsafe==1.1.1 1>> $arcus_directory/scripts/build.log 2>&1
+  printf "\r[python markupsafe library install] .. SUCCEED\n"
   printf "[python jinja2 library install] .. START"
   easy_install -a -d $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python jinja2 library install] .. SUCCEED\n"


### PR DESCRIPTION
jinja2의 의존성 문제 해결을 위해 markupsafe를 설치하는 부분을 build.sh에 추가하였습니다. 

관련 오류 내용은 java 클라이언트 [PR #236 ](https://github.com/naver/arcus-java-client/pull/236)을 참조하시기 바랍니다.

ci 테스트 결과 문제없이 빌드 되는 것이 확인되었습니다.

```
--------------------------
[git submodule init] .. SUCCEED
[git submodule update] .. SUCCEED
[server/config/autorun.sh] .. SUCCEED
[clients/c/config/autorun.sh] .. SUCCEED
[zookeeper/ant clean compile_jute bin-package] .. SUCCEED
[zookeeper/src/c/autoreconf -if] .. SUCCEED
[deps/libevent make clean] .. SUCCEED
[deps/libevent make] .. SUCCEED
[deps/libevent make install] .. SUCCEED
[zookeeper/src/c make clean] .. SUCCEED
[zookeeper/src/c make] .. SUCCEED
[zookeeper/src/c make install] .. SUCCEED
[server make clean] .. SUCCEED
[server make] .. SUCCEED
[server make install] .. SUCCEED
[python kazoo library install] .. SUCCEED
[python marupsafe library install] .. SUCCEED
[python jinja2 library install] .. SUCCEED
[python fabric library install] .. SUCCEED
--------------------------
ARCUS BUILD PROCESS: END
```

https://travis-ci.org/github/computerphilosopher/arcus-java-client/builds/677535384