### PR TITLE
FIX: use srvr commands to get zk mode

### DIFF
--- a/scripts/fabfile.py
+++ b/scripts/fabfile.py
@@ -378,7 +378,7 @@ def zk_config_id(iplist, clientport, myid):
 def zk_wait(clientport):
   """ Wait for ZooKeeper to come up and elect a leader. """
   sleep_seconds = 3
-  cmd = 'GOT=$(echo stat | nc localhost {0} | grep Mode:); if [ -z "$GOT" ]; then echo "Mode: stale"; else echo $GOT; fi'
+  cmd = 'GOT=$(echo srvr | nc localhost {0} | grep Mode:); if [ -z "$GOT" ]; then echo "Mode: stale"; else echo $GOT; fi'
   while True:
     complete = False
     has_stale = False


### PR DESCRIPTION
arcus 3.5.5 이상 버전에서는 srvr 을 제외한 4letter words는 whitelist에 추가하지 않으면 사용할 수 없습니다.

현재 fabfile.py에서는 모드를 얻기 위해 stat 명령을 사용하고 있는데, arcus-zookeeper 버전이 3.5.5 이상일 경우 오류가 생깁니다.

srvr 명령을 통해서도 모드를 확인할 수 있으므로 수정해서 PR합니다.

arcus-zookeeper 브랜치에 있는 모든 3.4.x 브랜치에 대해, srvr로 모드를 확인할 수 있는지 테스트 완료했습니다. 

arcus-3.4.5 버전
```
Zookeeper version: 3.4.5-p6--1, built on 10/26/2020 08:18 GMT
Latency min/avg/max: 0/0/10
Received: 49
Sent: 48
Connections: 5
Outstanding: 0
Zxid: 0x14228
Mode: standalone
Node count: 34
```

arcus-3.4.6 버전
```
Zookeeper version: 3.4.6--1, built on 10/29/2020 05:42 GMT
Latency min/avg/max: 0/0/7
Received: 45
Sent: 44
Connections: 5
Outstanding: 0
Zxid: 0x1424d
Mode: standalone
Node count: 34
```
