### PR TITLE
Docs: add omitted dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The commands assume RedHat/CentOS environment. If any problem exists in build, p
 # Requirements: JDK & Ant (java >= 1.8)
 
 # Install dependencies (python >= 2.6)
-sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel (CentOS)
-sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev (Ubuntu)
+sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel openssl-devel (CentOS)
+sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev libssl-dev (Ubuntu)
 
 
 # Clone & Build

--- a/docs/howto-install-dependencies.md
+++ b/docs/howto-install-dependencies.md
@@ -30,8 +30,8 @@ How To Install Dependencies
 - Install tools for packaging and building (python >= 2.6)
 
   ```
-  (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel
-  (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev
+  (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel openssl-devel
+  (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev libssl-dev
   ```
 
 - For OSX users


### PR DESCRIPTION
openssl 라이브러리가 없으면 libevent 빌드시 `openssl is a must but can not be found.` 오류가 발생하면서 빌드가 안 됩니다. 문서에서 누락되어 있어 추가합니다.


 