### PR TITLE
DOC: amended install guide documents.

### DIFF
--- a/docs/build-faq.md
+++ b/docs/build-faq.md
@@ -1,6 +1,6 @@
 ## cppunit.m4 missing
-cppunit.m4 가 없는 경우 Zookeeper build 지점에서 아래 에러가 발생하게 된다.  
-autoreconf 명령이 configure.ac을 실행하고, 이 파일은 cppunit.m4을 포함해서 여러 m4 매크로를 필요로 한다.
+Zookeeper 3.4 이하 버전을 사용하는 경우 cppunit.m4 가 없으면 아래와 같이 Zookeeper 컴파일 에러가 발생한다.
+`autoreconf -if` 은 cppunit.m4을 포함한 여러 m4 매크로 파일들을 필요로 한다.
 
 ```
 [zookeeper/zookeeper-client/zookeeper-client-c/autoreconf -if] .. FAILED

--- a/docs/howto-install-dependencies.md
+++ b/docs/howto-install-dependencies.md
@@ -8,9 +8,14 @@ How To Install Dependencies
   mkdir ~/vendor
   pushd ~/vendor
 
-  # Install openjdk
-  sudo yum install java-1.8.0-openjdk-devel.x86_64 (CentOS)
-  sudo apt-get install openjdk-8-jdk (Ubuntu)
+  # Install openjdk (Zookeeper 3.5.x required : 1.8u211 or higher version)
+  - CentOS
+    // check the installable version
+    yum list java*jdk-devel
+    // install the required version
+    sudo yum install java-1.8.0-openjdk-devel-<version>
+  - Ubuntu
+    sudo apt-get install openjdk-8-jdk
 
   # Install Apache-Ant
   curl -OL http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.3-bin.tar.gz
@@ -30,8 +35,15 @@ How To Install Dependencies
 - Install tools for packaging and building (python >= 2.6)
 
   ```
-  (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel
+  (CentOS) sudo yum install gcc gcc-c++ make autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel perl-Test-Harness perl-Test-Simple
   (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev
+  ```
+
+  - On CentOS8 system, you need to register the PowerTools repository to install cppunit-devel
+  ```
+  sudo yum install dnf-plugins-core
+  sudo yum config-manager --set-enabled PowerTools
+  sudo yum install cppunit-devel
   ```
 
 - For OSX users


### PR DESCRIPTION
build-faq.md 수정 
- cppunit.m4 missing 문제는 zookeeper 3.4 이하 버전에서만 해당하는 내용입니다. zookeeper 3.5 이상 버전에서는 cppunit.m4 을 필요로 하지 않아 cppunit 1.14 이상에서도 컴파일을 성공하는 것을 확인하였습니다.


howto-install-dependencies.md 수정
- zookeeper 3.5 이상에서 요구하는 jdk 버전은 1.8u211 이상입니다.
