### PR TITLE
FIX: use pip instead of easy_install

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,33 +97,36 @@ build_all() {
   fi
 
   # install python-kazoo, python-fabric
+  local pipversion="21.0"
   local pythonmajorversion=$(python -c 'import sys; print(sys.version_info[0])')
   local pythonpath=$target_dir/lib/python/site-packages
   local pythonsimpleindex=https://pypi.python.org/simple
+
+  pip install --upgrade "pip < $pipversion"
   mkdir -p $pythonpath
   export PYTHONPATH=$pythonpath:$PYTHONPATH
   printf "[python kazoo library install] .. START"
-  python -m easy_install -a -d $pythonpath -i $pythonsimpleindex kazoo==2.6.1 1>> $arcus_directory/scripts/build.log 2>&1
+  python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex kazoo==2.6.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python kazoo library install] .. SUCCEED\n"
   printf "[python markupsafe library install] .. START"
-  python -m easy_install -a -d $pythonpath -i $pythonsimpleindex markupsafe==1.1.1 1>> $arcus_directory/scripts/build.log 2>&1
+  python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex markupsafe==1.1.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python markupsafe library install] .. SUCCEED\n"
   printf "[python jinja2 library install] .. START"
-  python -m easy_install -a -d $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
+  python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python jinja2 library install] .. SUCCEED\n"
   printf "[python fabric library install] .. START"
   if [ "$pythonmajorversion" == "3" ]; then
-    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future python -m easy_install -a -d $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
-    python -m easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
+    python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
   else
     # FIXME pycrypto-2.6 is really really slow.. So let's downgrade it.
-    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future python -m easy_install -a -d $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
-    python -m easy_install -a -d $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
+    python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
   fi
   printf "\r[python fabric library install] .. SUCCEED\n"
   pushd $target_dir/scripts >> $arcus_directory/scripts/build.log
   if [ ! -f fab ]; then
-    ln -s ../lib/python/site-packages/fab fab 1>> $arcus_directory/scripts/build.log 2>&1
+    ln -s ../lib/python/site-packages/bin/fab fab 1>> $arcus_directory/scripts/build.log 2>&1
   fi
   popd >> $arcus_directory/scripts/build.log
 }


### PR DESCRIPTION
easy_install 대신 pip를 사용하도록 바꾸었습니다. arcus.sh이 정상 동작하는 것 확인하였습니다. 

- pip 버전이 낮을 경우 문법 에러가 발생할 수 있어 업데이트 하는 명령을 넣었습니다.
  - 21.0 부터 python2를 지원하지 않으므로 그보다 낮은 버전으로 설치되게 했습니다. 
- `-t` 옵션으로 경로를 지정해 설치합니다.
- `--upgrade` 옵션은 arcus/lib/site-packages에 해당 라이브러리의 구버전이 설치되어 있을 경우 버전업합니다.
- 모듈의 버전은 그대로 두었습니다. 

python3 migration은 이후 검토하겠습니다.