### PR TITLE
FIX: add whitelist config at zoo.cfg

### DIFF
--- a/scripts/conf/zoo.cfg
+++ b/scripts/conf/zoo.cfg
@@ -11,6 +11,8 @@ syncLimit=5
 dataDir={{ path }}/data
 # the port at which the clients will connect
 clientPort={{ port }}
+# 4 letter white list
+4lw.commands.whitelist=*
 minSessionTimeout=4000
 maxSessionTimeout=200000
 


### PR DESCRIPTION
@jhpark816 
- 클러스터 구성을 위해 `./arcus.sh zookeeper init` 명령어 실행 시 scripts/conf/zoo.cfg를 바탕으로 각 장비에서 사용될 실제 zoo.cfg 파일이 생성됩니다.
- 하지만 이 부분에 whitelist config가 빠져있어 `./arcus.sh zookeeper stat` 등의 명령어가 작동하지 않았으므로 config를 추가하였습니다.
- 정상 동작 테스트 완료하였습니다.