### PR TITLE
INTERNAL: Force to use python version 2 that is 2.6 or higher in build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The commands assume RedHat/CentOS environment. If any problem exists in build, p
 ```
 # Requirements: JDK & Ant (java >= 1.8)
 
-# Install dependencies (python >= 2.6)
+# Install dependencies (python version 2 that is 2.6 or higher)
 sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel python-pip nc (CentOS)
 sudo apt-get install build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev python-pip netcat (Ubuntu)
 

--- a/docs/howto-install-dependencies.md
+++ b/docs/howto-install-dependencies.md
@@ -32,7 +32,7 @@ How To Install Dependencies
   popd 
   ```
 
-- Install tools for packaging and building (python >= 2.6)
+- Install tools for packaging and building (python version 2 that is 2.6 or higher)
 
   ```
   (CentOS) sudo yum install gcc gcc-c++ make autoconf automake libtool pkgconfig cppunit-devel python-setuptools python-devel perl-Test-Harness perl-Test-Simple

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -100,31 +100,50 @@ build_all() {
   fi
 
   # install python-kazoo, python-fabric
+  local python_bin=$( (which python2.7 || which python2.6 || which python2 || which python) 2>/dev/null )
+  local pip_bin=$( (which pip2.7 || which pip2.6 || which pip2 || which pip) 2>/dev/null )
+
+  if [ -z "$python_bin" ]; then
+    echo "No python binary found. Install python version 2 that is 2.6 or higher."
+    exit 1
+  fi
+
+  if [ -z "$pip_bin" ]; then
+    echo "No pip binary found. Install pip version 2 that is 2.6 or higher."
+    exit 1
+  fi
+
+  local pythonmajorversion=$("$python_bin" -c 'import sys; print(sys.version_info[0])')
+  local pythonminorversion=$("$python_bin" -c 'import sys; print(sys.version_info[1])')
+  if [ "$pythonmajorversion" != "2" ] || [ "$pythonminorversion" -lt "6" ]; then
+    echo "Python version 2 that is 2.6 or higher is NOT found. Other version of python is NOT supported yet."
+    exit 1
+  fi
+
   local pipversion="21.0"
-  local pythonmajorversion=$(python -c 'import sys; print(sys.version_info[0])')
   local pythonpath=$target_dir/lib/python/site-packages
   local pythonsimpleindex=https://pypi.python.org/simple
 
-  pip install --upgrade "pip < $pipversion"
+  $pip_bin install --upgrade "pip < $pipversion"
   mkdir -p $pythonpath
   export PYTHONPATH=$pythonpath:$PYTHONPATH
   printf "[python kazoo library install] .. START"
-  python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex kazoo==2.6.1 1>> $arcus_directory/scripts/build.log 2>&1
+  $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex kazoo==2.6.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python kazoo library install] .. SUCCEED\n"
   printf "[python markupsafe library install] .. START"
-  python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex markupsafe==1.1.1 1>> $arcus_directory/scripts/build.log 2>&1
+  $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex markupsafe==1.1.1 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python markupsafe library install] .. SUCCEED\n"
   printf "[python jinja2 library install] .. START"
-  python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
+  $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex jinja2==2.10 1>> $arcus_directory/scripts/build.log 2>&1
   printf "\r[python jinja2 library install] .. SUCCEED\n"
   printf "[python fabric library install] .. START"
   if [ "$pythonmajorversion" == "3" ]; then
-    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
-    python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
+    $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
   else
     # FIXME pycrypto-2.6 is really really slow.. So let's downgrade it.
-    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
-    python -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
+    $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
   fi
   printf "\r[python fabric library install] .. SUCCEED\n"
   pushd $target_dir/scripts >> $arcus_directory/scripts/build.log


### PR DESCRIPTION
build.sh에서 python 2.7을 찾을 수 없으면 스크립트를 종료하도록 했습니다.

# Binary 파일 탐색

```bash
local python_bin=$(which python2.7 2>/dev/null || which python2 2>/dev/null || which python 2>/dev/null)
```

위 코드는 which 명령어로 python 2.7 -> python2 -> python 순서대로 python 바이너리 파일을 찾는 것입니다.
which 명령어가 실패하면 에러 메세지는 출력이 되지 않도록 `2>/dev/null`를 넣었습니다.
`2>/dev/null`가 중복이 되기 때문에 변수로 만들어서 사용하려고 했는데, 원인은 파악하지 못했지만 변수로 사용하면 다음과 같은 문제가 있어서 하드 코딩 했습니다.

- `2>/dev/null`를 변수로 사용하지 않는 경우
  1. python2.7을 찾으면 python2.7의 경로를 저장(set)하고 이 아래는 스킵
  2. python2를 찾으면 python2의 경로를 저장(set)하고 이 아래는 스킵
  3. python을 찾으면 python의 경로를 저장(set)
- `2>/dev/null`를 변수로 두고 사용하는 경우
  - ```bash
     local stderr_to_null="2>/dev/null"
     local python_bin=$(which python2.7 "$stderr_to_null" || which python2 "$stderr_to_null" || which python "$stderr_to_null")
    ```
  1. python2.7을 찾으면 python2.7의 경로를 저장(set)하고 아래의 로직을 계속 수행
  2. python2를 찾으면 python2의 경로를 끝에 덧붙이고(append) 아래의 로직을 계속 수행
  3. python을 찾으면 python의 경로를 끝에 덧붙임(append)

# Python 버전 검사

```bash
local pythonmajorversion=$("$python_bin" -c 'import sys; print(sys.version_info[0])')
local pythonminorversion=$("$python_bin" -c 'import sys; print(sys.version_info[1])')
if [ "$pythonmajorversion" != "2" ] || [ "$pythonminorversion" != "7" ]; then
  echo "No python 2.7 found. Other version of python is NOT supported yet."
  exit 1
fi
```

`sys.version_info`는 python 바이너리의 버전을 담고 있는 Array 입니다.
[0]에는 Major 버전, [1]에는 Minor 버전, [2]에는 Build 버전이 들어갑니다.
예를 들어 python 2.7.3인 경우 `[0] = 2, [1] = 7, [2] = 3` 입니다.
python의 2.x.x 버전은 2.7.x 버전이 최신이므로 2.7.x 버전인지 아닌지 검사하는 것입니다.

# 추가 논의 사항

## Python 버전 검사 관련

README에는 python 2.6 이상이 필요하다고 되어 있어서 README를 수정할지, 아니면 build 스크립트에서 Python 2.6도 허용할지 정해야 합니다.

## Python 버전에 따른 분기 관련

```bash
if [ "$pythonmajorversion" == "3" ]; then
  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycryptodome==3.9.7 1>> $arcus_directory/scripts/build.log 2>&1
  $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==2.5.0 1>> $arcus_directory/scripts/build.log 2>&1
else
  # FIXME pycrypto-2.6 is really really slow.. So let's downgrade it.
  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex pycrypto==2.4.1 1>> $arcus_directory/scripts/build.log 2>&1
  $python_bin -m pip install --upgrade -t $pythonpath -i $pythonsimpleindex fabric==1.8.3 1>> $arcus_directory/scripts/build.log 2>&1
fi
```

기존 빌드 스크립트에서는 Python이 3.x.x 버전인지 아닌지에 따라 분기를 하도록 되어 있습니다.
Python 3 버전으로도 build 스크립트는 잘 구동됩니다.

그러나 이미 알려진 이슈로, https://github.com/naver/arcus/issues/43 Python 3를 통해 arcus.sh 스크립트를 사용하면 아래와 같은 에러 메세지가 출력됩니다.

```
$ ./arcus.sh deploy conf/test.json
/root/arcus/lib/python/site-packages/paramiko/transport.py:32: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.6.
  from cryptography.hazmat.backends import default_backend
Traceback (most recent call last):
  File "/root/arcus/scripts/fab", line 8, in <module>
    sys.exit(program.run())
  File "/root/arcus/lib/python/site-packages/invoke/program.py", line 373, in run
    self.parse_collection()
  File "/root/arcus/lib/python/site-packages/invoke/program.py", line 465, in parse_collection
    self.load_collection()
  File "/root/arcus/lib/python/site-packages/fabric/main.py", line 87, in load_collection
    super(Fab, self).load_collection()
  File "/root/arcus/lib/python/site-packages/invoke/program.py", line 699, in load_collection
    module, parent = loader.load(coll_name)
  File "/root/arcus/lib/python/site-packages/invoke/loader.py", line 76, in load
    module = imp.load_module(name, fd, path, desc)
  File "/usr/lib64/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib64/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/arcus/scripts/fabfile.py", line 135
    print destination, os.path.isfile(destination)
                    ^
SyntaxError: invalid syntax
```

즉, build 스크립트에서 Python 버전이 3인지 아닌지는 고려할 대상이 아닙니다.
3이라면 arcus.sh 스크립트를 사용할 수 없기 때문입니다.

그러나 향후에는 Python 3 버전에 대한 지원이 가능해질 수도 있기 때문에 아래의 선택지 중 하나를 고를 수 있습니다.
1. 코드 보존을 위해 실제로는 소용이 없더라도 Python 3 버전에 대한 분기를 존치 (현재 PR)
2. 코드 보존은 하되 주석 처리
3. Python 3 버전에 대한 분기 자체를 제거