### PR TITLE
INTERNAL: Allow configuring image tag via environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     depends_on:
       register:
         condition: service_completed_successfully
-    image: jam2in/arcus-memcached
+    image: jam2in/arcus-memcached:${IMAGE_TAG:-latest}
     command: -m 100 -p 11211 -z zoo1:2181,zoo2:2181,zoo3:2181
     hostname: cache1
     ports:
@@ -60,7 +60,7 @@ services:
     depends_on:
       register:
         condition: service_completed_successfully
-    image: jam2in/arcus-memcached
+    image: jam2in/arcus-memcached:${IMAGE_TAG:-latest}
     command: -m 100 -p 11212 -z zoo1:2181,zoo2:2181,zoo3:2181
     hostname: cache2
     ports:
@@ -73,7 +73,7 @@ services:
     depends_on:
       register:
         condition: service_completed_successfully
-    image: jam2in/arcus-memcached
+    image: jam2in/arcus-memcached:${IMAGE_TAG:-latest}
     command: -m 100 -p 11213 -z zoo1:2181,zoo2:2181,zoo3:2181
     hostname: cache3
     ports:


### PR DESCRIPTION
CI 환경에서 필요에 따라 서로 다른 태그의 Docker 이미지를 사용하여 캐시 서버를 구동할 수 있도록 합니다.
IMAGE_TAG 환경 변수를 통해 Docker 이미지 태그를 설정할 수 있으며, 환경 변수가 없는 경우 기존과 동일한 태그인 latest를 사용합니다.