### PR TITLE
INTERNAL: Allow configuring replication server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,13 +41,14 @@ services:
       ZK_ENSEMBLE: zoo1:2181,zoo2:2181,zoo3:2181
       SERVICE_CODE: test
       CACHENODES: cache1:11211,cache2:11212,cache3:11213
+      IS_REPL: ${IS_REPL}
     restart: on-failure
 
   cache1:
     depends_on:
       register:
         condition: service_completed_successfully
-    image: jam2in/arcus-memcached:${IMAGE_TAG:-latest}
+    image: jam2in/arcus-memcached${REPL_IMAGE_SUFFIX}:${IMAGE_TAG:-latest}
     command: -m 100 -p 11211 -z zoo1:2181,zoo2:2181,zoo3:2181
     hostname: cache1
     ports:
@@ -60,7 +61,7 @@ services:
     depends_on:
       register:
         condition: service_completed_successfully
-    image: jam2in/arcus-memcached:${IMAGE_TAG:-latest}
+    image: jam2in/arcus-memcached${REPL_IMAGE_SUFFIX}:${IMAGE_TAG:-latest}
     command: -m 100 -p 11212 -z zoo1:2181,zoo2:2181,zoo3:2181
     hostname: cache2
     ports:
@@ -73,7 +74,7 @@ services:
     depends_on:
       register:
         condition: service_completed_successfully
-    image: jam2in/arcus-memcached:${IMAGE_TAG:-latest}
+    image: jam2in/arcus-memcached${REPL_IMAGE_SUFFIX}:${IMAGE_TAG:-latest}
     command: -m 100 -p 11213 -z zoo1:2181,zoo2:2181,zoo3:2181
     hostname: cache3
     ports:


### PR DESCRIPTION
Replication 서버를 구동할 수 있도록 합니다.
2개의 환경 변수에 적절한 값을 넣어야 Replication 서버를 구동할 수 있습니다.
- IS_REPL = "1"
- REPL_IMAGE_SUFFIX = "-ee"

단, Private 이미지이기 때문에 권한이 없는 Docker hub 유저는 Replication 서버를 구동할 수 없습니다.