### PR TITLE
FIX: Upgrade ZK Docker image version and enable JMX

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   zoo1:
-    image: zookeeper:3.5.9
+    image: zookeeper:3.9
     hostname: zoo1
     ports:
     - 2181:2181
@@ -10,8 +10,6 @@ services:
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
       ZOO_4LW_COMMANDS_WHITELIST: "stat"
-      JMXDISABLE: "true"
-      JVMFLAGS: "-Dzookeeper.jmx.log4j.disable=true"
     healthcheck:
       test: ["CMD", "sh", "-c", "echo stat | nc localhost 2181 | grep -q -E 'Mode: (follower|leader)'"]
       interval: 5s
@@ -21,7 +19,7 @@ services:
     restart: always
 
   zoo2:
-    image: zookeeper:3.5.9
+    image: zookeeper:3.9
     hostname: zoo2
     ports:
     - 2182:2181
@@ -29,8 +27,6 @@ services:
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
       ZOO_4LW_COMMANDS_WHITELIST: "stat"
-      JMXDISABLE: "true"
-      JVMFLAGS: "-Dzookeeper.jmx.log4j.disable=true"
     healthcheck:
       test: ["CMD", "sh", "-c", "echo stat | nc localhost 2181 | grep -q -E 'Mode: (follower|leader)'"]
       interval: 5s
@@ -40,7 +36,7 @@ services:
     restart: always
 
   zoo3:
-    image: zookeeper:3.5.9
+    image: zookeeper:3.9
     hostname: zoo3
     ports:
     - 2183:2181
@@ -48,8 +44,6 @@ services:
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
       ZOO_4LW_COMMANDS_WHITELIST: "stat"
-      JMXDISABLE: "true"
-      JVMFLAGS: "-Dzookeeper.jmx.log4j.disable=true"
     healthcheck:
       test: ["CMD", "sh", "-c", "echo stat | nc localhost 2181 | grep -q -E 'Mode: (follower|leader)'"]
       interval: 5s


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->

```
JMX disabled by user request
Using config: /conf/zoo.cfg
2025-10-20 03:14:51,236 [myid:] - INFO  [main:QuorumPeerConfig@136] - Reading configuration from: /conf/zoo.cfg
2025-10-20 03:14:51,241 [myid:] - INFO  [main:QuorumPeerConfig@378] - clientPort is not set
2025-10-20 03:14:51,241 [myid:] - INFO  [main:QuorumPeerConfig@392] - secureClientPort is not set
2025-10-20 03:14:51,270 [myid:1] - INFO  [main:DatadirCleanupManager@78] - autopurge.snapRetainCount set to 3
2025-10-20 03:14:51,273 [myid:1] - INFO  [main:DatadirCleanupManager@79] - autopurge.purgeInterval set to 0
2025-10-20 03:14:51,274 [myid:1] - INFO  [main:DatadirCleanupManager@101] - Purge task is not scheduled.
2025-10-20 03:14:51,275 [myid:1] - INFO  [main:ManagedUtil@40] - Log4j 1.2 jmx support is disabled by property.
2025-10-20 03:14:51,275 [myid:1] - INFO  [main:QuorumPeerMain@141] - Starting quorum peer, myid=1
2025-10-20 03:14:51,289 [myid:1] - INFO  [main:ServerCnxnFactory@135] - Using org.apache.zookeeper.server.NIOServerCnxnFactory as server connection factory
2025-10-20 03:14:51,295 [myid:1] - INFO  [main:NIOServerCnxnFactory@673] - Configuring NIO connection handler with 10s sessionless connection timeout, 1 selector thread(s), 8 worker threads, and 64 kB direct buffers.
2025-10-20 03:14:51,316 [myid:1] - INFO  [main:NIOServerCnxnFactory@686] - binding to port /0.0.0.0:2181
2025-10-20 03:14:51,415 [myid:1] - INFO  [main:Log@169] - Logging initialized @512ms to org.eclipse.jetty.util.log.Slf4jLog
2025-10-20 03:14:51,499 [myid:1] - WARN  [main:ContextHandler@1660] - o.e.j.s.ServletContextHandler@545997b1{/,null,STOPPED} contextPath ends with /*
2025-10-20 03:14:51,500 [myid:1] - WARN  [main:ContextHandler@1671] - Empty contextPath
2025-10-20 03:14:51,545 [myid:1] - INFO  [main:X509Util@79] - Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation
2025-10-20 03:14:51,549 [myid:1] - INFO  [main:FileTxnSnapLog@115] - zookeeper.snapshot.trust.empty : false
2025-10-20 03:14:51,558 [myid:1] - INFO  [main:QuorumPeer@1473] - Local sessions disabled
2025-10-20 03:14:51,558 [myid:1] - INFO  [main:QuorumPeer@1484] - Local session upgrading disabled
2025-10-20 03:14:51,559 [myid:1] - INFO  [main:QuorumPeer@1451] - tickTime set to 2000
2025-10-20 03:14:51,559 [myid:1] - INFO  [main:QuorumPeer@1495] - minSessionTimeout set to 4000
2025-10-20 03:14:51,559 [myid:1] - INFO  [main:QuorumPeer@1506] - maxSessionTimeout set to 40000
2025-10-20 03:14:51,560 [myid:1] - INFO  [main:QuorumPeer@1521] - initLimit set to 5
2025-10-20 03:14:51,575 [myid:1] - INFO  [main:ZKDatabase@117] - zookeeper.snapshotSizeFactor = 0.33
2025-10-20 03:14:51,577 [myid:1] - INFO  [main:QuorumPeer@1771] - Using insecure (non-TLS) quorum communication
2025-10-20 03:14:51,577 [myid:1] - INFO  [main:QuorumPeer@1777] - Port unification disabled
2025-10-20 03:14:51,577 [myid:1] - INFO  [main:QuorumPeer@2145] - QuorumPeer communication is not secured! (SASL auth disabled)
2025-10-20 03:14:51,577 [myid:1] - INFO  [main:QuorumPeer@2174] - quorum.cnxn.threads.size set to 20
2025-10-20 03:14:51,582 [myid:1] - INFO  [main:FileTxnSnapLog@404] - Snapshotting: 0x0 to /data/version-2/snapshot.0
2025-10-20 03:14:51,586 [myid:1] - INFO  [main:QuorumPeer@916] - currentEpoch not found! Creating with a reasonable default of 0. This should only happen when you are upgrading your installation
2025-10-20 03:14:51,597 [myid:1] - INFO  [main:QuorumPeer@931] - acceptedEpoch not found! Creating with a reasonable default of 0. This should only happen when you are upgrading your installation
2025-10-20 03:14:51,609 [myid:1] - INFO  [main:Server@375] - jetty-9.4.35.v20201120; built: 2020-11-20T21:17:03.964Z; git: bdc54f03a5e0a7e280fab27f55c3c75ee8da89fb; jvm 11.0.16+8
2025-10-20 03:14:51,659 [myid:1] - INFO  [main:DefaultSessionIdManager@334] - DefaultSessionIdManager workerName=node0
2025-10-20 03:14:51,659 [myid:1] - INFO  [main:DefaultSessionIdManager@339] - No SessionScavenger set, using defaults
2025-10-20 03:14:51,662 [myid:1] - INFO  [main:HouseKeeper@132] - node0 Scavenging every 660000ms
2025-10-20 03:14:51,665 [myid:1] - WARN  [main:ConstraintSecurityHandler@758] - ServletContext@o.e.j.s.ServletContextHandler@545997b1{/,null,STARTING} has uncovered http methods for path: /*
2025-10-20 03:14:51,675 [myid:1] - INFO  [main:ContextHandler@916] - Started o.e.j.s.ServletContextHandler@545997b1{/,null,AVAILABLE}
2025-10-20 03:14:51,691 [myid:1] - INFO  [main:AbstractConnector@331] - Started ServerConnector@7d70d1b1{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2025-10-20 03:14:51,691 [myid:1] - INFO  [main:Server@415] - Started @801ms
2025-10-20 03:14:51,694 [myid:1] - INFO  [main:JettyAdminServer@116] - Started AdminServer on address 0.0.0.0, port 8080 and command URL /commands
2025-10-20 03:14:51,707 [myid:1] - INFO  [main:QuorumCnxManager$Listener@878] - Election port bind maximum retries is 3
2025-10-20 03:14:51,710 [myid:1] - INFO  [QuorumPeerListener:QuorumCnxManager$Listener@929] - 1 is accepting connections now, my election bind port: zoo1/172.18.0.3:3888
2025-10-20 03:14:51,823 [myid:1] - WARN  [QuorumPeer[myid=1](plain=[0:0:0:0:0:0:0:0]:2181)(secure=disabled):ZooKeeperThread@55] - Exception occurred from thread QuorumPeer[myid=1](plain=[0:0:0:0:0:0:0:0]:2181)(secure=disabled)
java.lang.ExceptionInInitializerError
  at org.apache.zookeeper.server.quorum.QuorumPeer.run(QuorumPeer.java:1145)
Caused by: java.lang.NullPointerException
  at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(Unknown Source)
  at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(Unknown Source)
  at java.base/jdk.internal.platform.CgroupMetrics.getInstance(Unknown Source)
  at java.base/jdk.internal.platform.SystemMetrics.instance(Unknown Source)
  at java.base/jdk.internal.platform.Metrics.systemMetrics(Unknown Source)
  at java.base/jdk.internal.platform.Container.metrics(Unknown Source)
  at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(Unknown Source)
  at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(Unknown Source)
  at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(Unknown Source)
  at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(Unknown Source)
  at java.base/java.util.stream.ReferencePipeline$7$1.accept(Unknown Source)
  at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
  at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(Unknown Source)
  at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
  at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
  at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
  at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
  at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
  at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
  at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(Unknown Source)
  at org.apache.zookeeper.jmx.MBeanRegistry.<init>(MBeanRegistry.java:70)
  at org.apache.zookeeper.jmx.MBeanRegistry.<clinit>(MBeanRegistry.java:46)
  ... 1 more
2025-10-20 03:14:51,827 [myid:1] - INFO  [main:QuorumPeerMain@104] - Exiting normally
JMX disabled by user request
Using config: /conf/zoo.cfg
2025-10-20 03:14:52,907 [myid:] - INFO  [main:QuorumPeerConfig@136] - Reading configuration from: /conf/zoo.cfg
2025-10-20 03:14:52,911 [myid:] - INFO  [main:QuorumPeerConfig@378] - clientPort is not set
2025-10-20 03:14:52,912 [myid:] - INFO  [main:QuorumPeerConfig@392] - secureClientPort is not set
2025-10-20 03:14:52,939 [myid:1] - INFO  [main:DatadirCleanupManager@78] - autopurge.snapRetainCount set to 3
2025-10-20 03:14:52,940 [myid:1] - INFO  [main:DatadirCleanupManager@79] - autopurge.purgeInterval set to 0
2025-10-20 03:14:52,941 [myid:1] - INFO  [main:DatadirCleanupManager@101] - Purge task is not scheduled.
2025-10-20 03:14:52,943 [myid:1] - INFO  [main:ManagedUtil@40] - Log4j 1.2 jmx support is disabled by property.
2025-10-20 03:14:52,943 [myid:1] - INFO  [main:QuorumPeerMain@141] - Starting quorum peer, myid=1
2025-10-20 03:14:52,952 [myid:1] - INFO  [main:ServerCnxnFactory@135] - Using org.apache.zookeeper.server.NIOServerCnxnFactory as server connection factory
2025-10-20 03:14:52,956 [myid:1] - INFO  [main:NIOServerCnxnFactory@673] - Configuring NIO connection handler with 10s sessionless connection timeout, 1 selector thread(s), 8 worker threads, and 64 kB direct buffers.
2025-10-20 03:14:52,971 [myid:1] - INFO  [main:NIOServerCnxnFactory@686] - binding to port /0.0.0.0:2181
2025-10-20 03:14:53,056 [myid:1] - INFO  [main:Log@169] - Logging initialized @483ms to org.eclipse.jetty.util.log.Slf4jLog
2025-10-20 03:14:53,170 [myid:1] - WARN  [main:ContextHandler@1660] - o.e.j.s.ServletContextHandler@545997b1{/,null,STOPPED} contextPath ends with /*
2025-10-20 03:14:53,171 [myid:1] - WARN  [main:ContextHandler@1671] - Empty contextPath
2025-10-20 03:14:53,192 [myid:1] - INFO  [main:X509Util@79] - Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation
2025-10-20 03:14:53,197 [myid:1] - INFO  [main:FileTxnSnapLog@115] - zookeeper.snapshot.trust.empty : false
2025-10-20 03:14:53,209 [myid:1] - INFO  [main:QuorumPeer@1473] - Local sessions disabled
2025-10-20 03:14:53,209 [myid:1] - INFO  [main:QuorumPeer@1484] - Local session upgrading disabled
2025-10-20 03:14:53,210 [myid:1] - INFO  [main:QuorumPeer@1451] - tickTime set to 2000
2025-10-20 03:14:53,210 [myid:1] - INFO  [main:QuorumPeer@1495] - minSessionTimeout set to 4000
2025-10-20 03:14:53,210 [myid:1] - INFO  [main:QuorumPeer@1506] - maxSessionTimeout set to 40000
2025-10-20 03:14:53,212 [myid:1] - INFO  [main:QuorumPeer@1521] - initLimit set to 5
2025-10-20 03:14:53,248 [myid:1] - INFO  [main:ZKDatabase@117] - zookeeper.snapshotSizeFactor = 0.33
2025-10-20 03:14:53,250 [myid:1] - INFO  [main:QuorumPeer@1771] - Using insecure (non-TLS) quorum communication
2025-10-20 03:14:53,250 [myid:1] - INFO  [main:QuorumPeer@1777] - Port unification disabled
2025-10-20 03:14:53,251 [myid:1] - INFO  [main:QuorumPeer@2145] - QuorumPeer communication is not secured! (SASL auth disabled)
2025-10-20 03:14:53,251 [myid:1] - INFO  [main:QuorumPeer@2174] - quorum.cnxn.threads.size set to 20
2025-10-20 03:14:53,252 [myid:1] - INFO  [main:FileSnap@83] - Reading snapshot /data/version-2/snapshot.0
2025-10-20 03:14:53,263 [myid:1] - INFO  [main:Server@375] - jetty-9.4.35.v20201120; built: 2020-11-20T21:17:03.964Z; git: bdc54f03a5e0a7e280fab27f55c3c75ee8da89fb; jvm 11.0.16+8
2025-10-20 03:14:53,348 [myid:1] - INFO  [main:DefaultSessionIdManager@334] - DefaultSessionIdManager workerName=node0
2025-10-20 03:14:53,350 [myid:1] - INFO  [main:DefaultSessionIdManager@339] - No SessionScavenger set, using defaults
2025-10-20 03:14:53,371 [myid:1] - INFO  [main:HouseKeeper@132] - node0 Scavenging every 600000ms
2025-10-20 03:14:53,376 [myid:1] - WARN  [main:ConstraintSecurityHandler@758] - ServletContext@o.e.j.s.ServletContextHandler@545997b1{/,null,STARTING} has uncovered http methods for path: /*
2025-10-20 03:14:53,396 [myid:1] - INFO  [main:ContextHandler@916] - Started o.e.j.s.ServletContextHandler@545997b1{/,null,AVAILABLE}
2025-10-20 03:14:53,419 [myid:1] - INFO  [main:AbstractConnector@331] - Started ServerConnector@7d70d1b1{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2025-10-20 03:14:53,421 [myid:1] - INFO  [main:Server@415] - Started @859ms
2025-10-20 03:14:53,422 [myid:1] - INFO  [main:JettyAdminServer@116] - Started AdminServer on address 0.0.0.0, port 8080 and command URL /commands
2025-10-20 03:14:53,440 [myid:1] - INFO  [main:QuorumCnxManager$Listener@878] - Election port bind maximum retries is 3
2025-10-20 03:14:53,442 [myid:1] - INFO  [QuorumPeerListener:QuorumCnxManager$Listener@929] - 1 is accepting connections now, my election bind port: zoo1/172.18.0.2:3888
2025-10-20 03:14:53,520 [myid:1] - WARN  [QuorumPeer[myid=1](plain=[0:0:0:0:0:0:0:0]:2181)(secure=disabled):ZooKeeperThread@55] - Exception occurred from thread QuorumPeer[myid=1](plain=[0:0:0:0:0:0:0:0]:2181)(secure=disabled)
java.lang.ExceptionInInitializerError
  at org.apache.zookeeper.server.quorum.QuorumPeer.run(QuorumPeer.java:1145)
Caused by: java.lang.NullPointerException
  at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(Unknown Source)
  at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(Unknown Source)
  at java.base/jdk.internal.platform.CgroupMetrics.getInstance(Unknown Source)
  at java.base/jdk.internal.platform.SystemMetrics.instance(Unknown Source)
  at java.base/jdk.internal.platform.Metrics.systemMetrics(Unknown Source)
  at java.base/jdk.internal.platform.Container.metrics(Unknown Source)
  at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(Unknown Source)
  at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(Unknown Source)
  at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(Unknown Source)
  at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(Unknown Source)
  at java.base/java.util.stream.ReferencePipeline$7$1.accept(Unknown Source)
  at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
  at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(Unknown Source)
  at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
  at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
  at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
  at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
  at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
  at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
  at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(Unknown Source)
  at org.apache.zookeeper.jmx.MBeanRegistry.<init>(MBeanRegistry.java:70)
  at org.apache.zookeeper.jmx.MBeanRegistry.<clinit>(MBeanRegistry.java:46)
  ... 1 more
2025-10-20 03:14:53,523 [myid:1] - INFO  [main:QuorumPeerMain@104] - Exiting normally
JMX disabled by user request
Using config: /conf/zoo.cfg
```

- https://github.com/naver/arcus/pull/70
- JMX 기능은 비활성화되어 있으나, ZK 소스 코드 내부적으로 항상 MBean 객체를 초기화하기 때문에 여전히 이슈가 발생한다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ZK 도커 이미지 버전을 최신 버전으로 올립니다.
- 로컬에서 Java Client 테스트 코드는 최신 버전의 ZK 도커 이미지로도 정상 수행되는 것을 확인했습니다.